### PR TITLE
Replace `dyn RngCore` with custom `RandomGenerator` impl to avoid dyn…

### DIFF
--- a/moors/src/algorithms/helpers/initialization.rs
+++ b/moors/src/algorithms/helpers/initialization.rs
@@ -20,7 +20,7 @@ impl Initialization {
         survivor: &Sur,
         evaluator: &Evaluator<F, G>,
         duplicates_cleaner: &Option<DC>,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
         context: &AlgorithmContext,
     ) -> Result<Population, InitializationError>
     where

--- a/moors/src/operators/crossover/exponential.rs
+++ b/moors/src/operators/crossover/exponential.rs
@@ -30,7 +30,7 @@ impl CrossoverOperator for ExponentialCrossover {
         &self,
         parent_a: &IndividualGenes,
         parent_b: &IndividualGenes,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> (IndividualGenes, IndividualGenes) {
         let len = parent_a.len();
         assert_eq!(len, parent_b.len());
@@ -107,7 +107,8 @@ mod tests {
 
     impl RandomGenerator for FakeRandom {
         /// Returns a mutable reference to the underlying dummy RNG.
-        fn rng(&mut self) -> &mut dyn rand::RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
 

--- a/moors/src/operators/crossover/mod.rs
+++ b/moors/src/operators/crossover/mod.rs
@@ -24,7 +24,7 @@ pub trait CrossoverOperator: GeneticOperator {
         &self,
         parent_a: &IndividualGenes,
         parent_b: &IndividualGenes,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> (IndividualGenes, IndividualGenes);
 
     /// Applies the crossover operator to the population.
@@ -35,7 +35,7 @@ pub trait CrossoverOperator: GeneticOperator {
         parents_a: &PopulationGenes,
         parents_b: &PopulationGenes,
         crossover_rate: f64,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> PopulationGenes {
         let population_size = parents_a.nrows();
         assert_eq!(

--- a/moors/src/operators/crossover/order.rs
+++ b/moors/src/operators/crossover/order.rs
@@ -25,7 +25,7 @@ impl CrossoverOperator for OrderCrossover {
         &self,
         parent_a: &IndividualGenes,
         parent_b: &IndividualGenes,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> (IndividualGenes, IndividualGenes) {
         let len = parent_a.len();
         assert_eq!(len, parent_b.len());
@@ -85,7 +85,6 @@ mod tests {
     use crate::genetic::IndividualGenes;
     use crate::random::{RandomGenerator, TestDummyRng};
     use ndarray::Array1;
-    use rand::RngCore;
 
     /// A controlled fake RandomGenerator that returns predetermined values for `gen_range_usize`.
     /// For this test, it will return 2 on the first call and 5 on the second call.
@@ -106,7 +105,8 @@ mod tests {
     }
 
     impl RandomGenerator for ControlledFakeRandomGenerator {
-        fn rng(&mut self) -> &mut dyn RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
         fn gen_range_usize(&mut self, _min: usize, _max: usize) -> usize {

--- a/moors/src/operators/crossover/sbx.rs
+++ b/moors/src/operators/crossover/sbx.rs
@@ -49,7 +49,7 @@ pub fn sbx_crossover_array(
     p2: &Array1<f64>,
     distribution_index: f64,
     prob_exchange: f64,
-    rng: &mut dyn RandomGenerator,
+    rng: &mut impl RandomGenerator,
 ) -> (Array1<f64>, Array1<f64>) {
     let n = p1.len();
     let eps = 1e-16;
@@ -115,7 +115,7 @@ impl CrossoverOperator for SimulatedBinaryCrossover {
         &self,
         parent_a: &IndividualGenes,
         parent_b: &IndividualGenes,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> (IndividualGenes, IndividualGenes) {
         // TODO: Enable prob_exchange
         sbx_crossover_array(parent_a, parent_b, self.distribution_index, 0.0, rng)
@@ -151,7 +151,8 @@ mod tests {
     }
 
     impl RandomGenerator for FakeRandom {
-        fn rng(&mut self) -> &mut dyn rand::RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
         fn gen_proability(&mut self) -> f64 {

--- a/moors/src/operators/crossover/single_point.rs
+++ b/moors/src/operators/crossover/single_point.rs
@@ -25,7 +25,7 @@ impl CrossoverOperator for SinglePointBinaryCrossover {
         &self,
         parent_a: &IndividualGenes,
         parent_b: &IndividualGenes,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> (IndividualGenes, IndividualGenes) {
         let num_genes = parent_a.len();
         assert_eq!(
@@ -63,7 +63,6 @@ mod tests {
     use super::*;
     use ndarray::Array1;
     use ndarray::array;
-    use rand::RngCore;
 
     use crate::random::{RandomGenerator, TestDummyRng};
 
@@ -85,7 +84,8 @@ mod tests {
     }
 
     impl RandomGenerator for ControlledFakeRandomGenerator {
-        fn rng(&mut self) -> &mut dyn RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
         fn gen_range_usize(&mut self, _min: usize, _max: usize) -> usize {

--- a/moors/src/operators/crossover/uniform_binary.rs
+++ b/moors/src/operators/crossover/uniform_binary.rs
@@ -23,7 +23,7 @@ impl CrossoverOperator for UniformBinaryCrossover {
         &self,
         parent_a: &IndividualGenes,
         parent_b: &IndividualGenes,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> (IndividualGenes, IndividualGenes) {
         assert_eq!(
             parent_a.len(),
@@ -56,7 +56,6 @@ mod tests {
     use super::*;
     use crate::random::{RandomGenerator, TestDummyRng};
     use ndarray::{Array1, array};
-    use rand::RngCore;
 
     /// A controlled fake random generator that returns predetermined values for `gen_proability()`.
     struct ControlledFakeProbabilityGenerator {
@@ -79,7 +78,8 @@ mod tests {
     }
 
     impl RandomGenerator for ControlledFakeProbabilityGenerator {
-        fn rng(&mut self) -> &mut dyn RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
         // Override the default `gen_proability()` to return controlled values.

--- a/moors/src/operators/evolve.rs
+++ b/moors/src/operators/evolve.rs
@@ -90,7 +90,7 @@ where
         &self,
         parents_a: &PopulationGenes,
         parents_b: &PopulationGenes,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> PopulationGenes {
         // 1) Perform crossover in one batch.
         let mut offsprings = self
@@ -142,7 +142,7 @@ where
         population: &Population,
         num_offsprings: usize,
         max_iter: usize,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> Result<PopulationGenes, EvolveError> {
         // Accumulate offspring rows in a Vec<Vec<f64>>
         let mut all_offsprings: Vec<Vec<f64>> = Vec::with_capacity(num_offsprings);

--- a/moors/src/operators/mutation/bitflip.rs
+++ b/moors/src/operators/mutation/bitflip.rs
@@ -24,7 +24,7 @@ impl GeneticOperator for BitFlipMutation {
 }
 
 impl MutationOperator for BitFlipMutation {
-    fn mutate<'a>(&self, mut individual: IndividualGenesMut<'a>, rng: &mut dyn RandomGenerator) {
+    fn mutate<'a>(&self, mut individual: IndividualGenesMut<'a>, rng: &mut impl RandomGenerator) {
         for gene in individual.iter_mut() {
             if rng.gen_bool(self.gene_mutation_rate) {
                 *gene = if *gene == 0.0 { 1.0 } else { 0.0 };
@@ -39,7 +39,6 @@ mod tests {
     use crate::genetic::PopulationGenes;
     use crate::random::{RandomGenerator, TestDummyRng};
     use ndarray::array;
-    use rand::RngCore;
 
     /// A fake RandomGenerator for testing that always returns `true` for `gen_bool`.
     struct FakeRandomGeneratorTrue {
@@ -55,7 +54,8 @@ mod tests {
     }
 
     impl RandomGenerator for FakeRandomGeneratorTrue {
-        fn rng(&mut self) -> &mut dyn RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
         fn gen_bool(&mut self, _p: f64) -> bool {

--- a/moors/src/operators/mutation/displacement.rs
+++ b/moors/src/operators/mutation/displacement.rs
@@ -24,7 +24,7 @@ impl GeneticOperator for DisplacementMutation {
 }
 
 impl MutationOperator for DisplacementMutation {
-    fn mutate<'a>(&self, mut individual: IndividualGenesMut<'a>, rng: &mut dyn RandomGenerator) {
+    fn mutate<'a>(&self, mut individual: IndividualGenesMut<'a>, rng: &mut impl RandomGenerator) {
         let n = individual.len();
 
         // Select two random indices to define the segment boundaries.
@@ -88,7 +88,8 @@ mod tests {
     }
 
     impl RandomGenerator for FakeRandomGeneratorDisplacement {
-        fn rng(&mut self) -> &mut dyn rand::RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
         fn gen_range_usize(&mut self, _min: usize, _max: usize) -> usize {

--- a/moors/src/operators/mutation/gaussian.rs
+++ b/moors/src/operators/mutation/gaussian.rs
@@ -29,7 +29,7 @@ impl GeneticOperator for GaussianMutation {
 }
 
 impl MutationOperator for GaussianMutation {
-    fn mutate<'a>(&self, mut individual: IndividualGenesMut<'a>, rng: &mut dyn RandomGenerator) {
+    fn mutate<'a>(&self, mut individual: IndividualGenesMut<'a>, rng: &mut impl RandomGenerator) {
         // Create a normal distribution with mean 0.0 and standard deviation sigma.
         let normal_dist = Normal::new(0.0, self.sigma)
             .expect("Failed to create normal distribution. Sigma must be > 0.");

--- a/moors/src/operators/mutation/mod.rs
+++ b/moors/src/operators/mutation/mod.rs
@@ -26,14 +26,14 @@ pub trait MutationOperator: GeneticOperator {
     ///
     /// * `individual` - The individual to mutate, provided as a mutable view.
     /// * `rng` - A random number generator.
-    fn mutate<'a>(&self, individual: IndividualGenesMut<'a>, rng: &mut dyn RandomGenerator);
+    fn mutate<'a>(&self, individual: IndividualGenesMut<'a>, rng: &mut impl RandomGenerator);
 
     /// Selects individuals for mutation based on the mutation rate.
     fn select_individuals_for_mutation(
         &self,
         population_size: usize,
         mutation_rate: f64,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> Vec<bool> {
         (0..population_size)
             .map(|_| rng.gen_bool(mutation_rate))
@@ -51,7 +51,7 @@ pub trait MutationOperator: GeneticOperator {
         &self,
         population: &mut PopulationGenes,
         mutation_rate: f64,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) {
         // Get the number of individuals (i.e. the number of rows).
         let population_size = population.len_of(Axis(0));

--- a/moors/src/operators/mutation/scramble.rs
+++ b/moors/src/operators/mutation/scramble.rs
@@ -23,7 +23,7 @@ impl GeneticOperator for ScrambleMutation {
 }
 
 impl MutationOperator for ScrambleMutation {
-    fn mutate<'a>(&self, mut individual: IndividualGenesMut<'a>, rng: &mut dyn RandomGenerator) {
+    fn mutate<'a>(&self, mut individual: IndividualGenesMut<'a>, rng: &mut impl RandomGenerator) {
         let n = individual.len();
         // Select two random indices to define the segment.
         let idx1 = rng.gen_range_usize(0, n);
@@ -52,7 +52,6 @@ mod tests {
     use super::*;
     use crate::random::{RandomGenerator, TestDummyRng};
     use ndarray::{Array1, array};
-    use rand::RngCore;
     use rstest::rstest;
 
     /// A fake RandomGenerator for scramble mutation testing.
@@ -72,7 +71,8 @@ mod tests {
     }
 
     impl RandomGenerator for FakeRandomGeneratorScramble {
-        fn rng(&mut self) -> &mut dyn RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.fake_rng
         }
 

--- a/moors/src/operators/mutation/swap.rs
+++ b/moors/src/operators/mutation/swap.rs
@@ -23,7 +23,7 @@ impl GeneticOperator for SwapMutation {
 /// In a typical permutation-based setup, each row is an array of distinct values.
 /// The "swap" mutation picks two indices at random and swaps them.
 impl MutationOperator for SwapMutation {
-    fn mutate<'a>(&self, mut individual: IndividualGenesMut<'a>, rng: &mut dyn RandomGenerator) {
+    fn mutate<'a>(&self, mut individual: IndividualGenesMut<'a>, rng: &mut impl RandomGenerator) {
         let length = individual.len();
         // If there is at most one element, there's nothing to swap.
         if length > 1 {
@@ -46,7 +46,6 @@ mod tests {
     use crate::genetic::PopulationGenes;
     use crate::random::{RandomGenerator, TestDummyRng};
     use ndarray::array;
-    use rand::RngCore;
 
     /// A controlled fake RandomGenerator that returns predetermined values for `gen_range_usize`.
     struct ControlledFakeRandomGenerator {
@@ -67,7 +66,8 @@ mod tests {
     }
 
     impl RandomGenerator for ControlledFakeRandomGenerator {
-        fn rng(&mut self) -> &mut dyn RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
 

--- a/moors/src/operators/sampling/mod.rs
+++ b/moors/src/operators/sampling/mod.rs
@@ -12,14 +12,15 @@ pub use random::{RandomSamplingBinary, RandomSamplingFloat, RandomSamplingInt};
 
 pub trait SamplingOperator: GeneticOperator {
     /// Samples a single individual.
-    fn sample_individual(&self, num_vars: usize, rng: &mut dyn RandomGenerator) -> IndividualGenes;
+    fn sample_individual(&self, num_vars: usize, rng: &mut impl RandomGenerator)
+    -> IndividualGenes;
 
     /// Samples a population of individuals.
     fn operate(
         &self,
         population_size: usize,
         num_vars: usize,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> PopulationGenes {
         let mut population = Vec::with_capacity(population_size);
 

--- a/moors/src/operators/sampling/permutation.rs
+++ b/moors/src/operators/sampling/permutation.rs
@@ -27,7 +27,11 @@ impl GeneticOperator for PermutationSampling {
 impl SamplingOperator for PermutationSampling {
     /// Generates a single individual of length `num_vars` where the genes
     /// are a shuffled permutation of the integers [0, 1, 2, ..., num_vars - 1].
-    fn sample_individual(&self, num_vars: usize, rng: &mut dyn RandomGenerator) -> IndividualGenes {
+    fn sample_individual(
+        &self,
+        num_vars: usize,
+        rng: &mut impl RandomGenerator,
+    ) -> IndividualGenes {
         // 1) Create a vector of indices [0, 1, 2, ..., num_vars - 1]
         let mut indices: Vec<f64> = (0..num_vars).map(|i| i as f64).collect();
 
@@ -42,10 +46,9 @@ impl SamplingOperator for PermutationSampling {
 mod tests {
     use super::*;
     use crate::random::{RandomGenerator, TestDummyRng};
-    use rand::RngCore;
 
     /// A fake RandomGenerator for testing. It contains a TestDummyRng to provide
-    /// the required RngCore behavior.
+    /// the required RandomGenerator behavior.
     struct FakeRandomGenerator {
         dummy: TestDummyRng,
     }
@@ -59,7 +62,8 @@ mod tests {
     }
 
     impl RandomGenerator for FakeRandomGenerator {
-        fn rng(&mut self) -> &mut dyn RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             // Return a mutable reference to the internal dummy RNG.
             &mut self.dummy
         }

--- a/moors/src/operators/sampling/random/binary.rs
+++ b/moors/src/operators/sampling/random/binary.rs
@@ -23,7 +23,11 @@ impl GeneticOperator for RandomSamplingBinary {
 }
 
 impl SamplingOperator for RandomSamplingBinary {
-    fn sample_individual(&self, num_vars: usize, rng: &mut dyn RandomGenerator) -> IndividualGenes {
+    fn sample_individual(
+        &self,
+        num_vars: usize,
+        rng: &mut impl RandomGenerator,
+    ) -> IndividualGenes {
         (0..num_vars)
             .map(|_| if rng.gen_bool(0.5) { 1.0 } else { 0.0 })
             .collect()

--- a/moors/src/operators/sampling/random/float.rs
+++ b/moors/src/operators/sampling/random/float.rs
@@ -26,7 +26,11 @@ impl GeneticOperator for RandomSamplingFloat {
 }
 
 impl SamplingOperator for RandomSamplingFloat {
-    fn sample_individual(&self, num_vars: usize, rng: &mut dyn RandomGenerator) -> IndividualGenes {
+    fn sample_individual(
+        &self,
+        num_vars: usize,
+        rng: &mut impl RandomGenerator,
+    ) -> IndividualGenes {
         (0..num_vars)
             .map(|_| rng.gen_range_f64(self.min, self.max))
             .collect()

--- a/moors/src/operators/sampling/random/int.rs
+++ b/moors/src/operators/sampling/random/int.rs
@@ -26,7 +26,11 @@ impl GeneticOperator for RandomSamplingInt {
 }
 
 impl SamplingOperator for RandomSamplingInt {
-    fn sample_individual(&self, num_vars: usize, rng: &mut dyn RandomGenerator) -> IndividualGenes {
+    fn sample_individual(
+        &self,
+        num_vars: usize,
+        rng: &mut impl RandomGenerator,
+    ) -> IndividualGenes {
         (0..num_vars)
             .map(|_| rng.gen_range_f64(self.min as f64, self.max as f64))
             .collect()

--- a/moors/src/operators/sampling/random/mod.rs
+++ b/moors/src/operators/sampling/random/mod.rs
@@ -9,7 +9,6 @@ pub use int::RandomSamplingInt;
 #[cfg(test)]
 mod tests {
     use crate::random::{RandomGenerator, TestDummyRng};
-    use rand::RngCore;
 
     use crate::operators::sampling::random::binary::RandomSamplingBinary;
     use crate::operators::sampling::random::float::RandomSamplingFloat;
@@ -33,7 +32,8 @@ mod tests {
     }
 
     impl RandomGenerator for FakeRandomGenerator {
-        fn rng(&mut self) -> &mut dyn RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
         fn gen_range_usize(&mut self, min: usize, _max: usize) -> usize {

--- a/moors/src/operators/selection/mod.rs
+++ b/moors/src/operators/selection/mod.rs
@@ -34,7 +34,7 @@ pub trait SelectionOperator: GeneticOperator {
         &self,
         population_size: usize,
         n_crossovers: usize,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> Vec<Vec<usize>> {
         // Note that we have fixed n_parents = 2 and pressure = 2
         let total_needed = n_crossovers * self.n_parents_per_crossover() * self.pressure();
@@ -64,14 +64,14 @@ pub trait SelectionOperator: GeneticOperator {
         &self,
         p1: &Individual,
         p2: &Individual,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> DuelResult;
 
     fn operate(
         &self,
         population: &Population,
         n_crossovers: usize,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> (Population, Population) {
         let population_size = population.len();
 

--- a/moors/src/operators/selection/random_tournament.rs
+++ b/moors/src/operators/selection/random_tournament.rs
@@ -24,7 +24,7 @@ impl SelectionOperator for RandomSelection {
         &self,
         p1: &Individual,
         p2: &Individual,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
     ) -> DuelResult {
         let p1_feasible = p1.is_feasible();
         let p2_feasible = p2.is_feasible();
@@ -68,7 +68,8 @@ mod tests {
     }
 
     impl RandomGenerator for FakeRandomGenerator {
-        fn rng(&mut self) -> &mut dyn rand::RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
         fn gen_bool(&mut self, _p: f64) -> bool {

--- a/moors/src/operators/selection/rank_and_survival_scoring_tournament.rs
+++ b/moors/src/operators/selection/rank_and_survival_scoring_tournament.rs
@@ -41,7 +41,7 @@ impl SelectionOperator for RankAndScoringSelection {
         &self,
         p1: &Individual,
         p2: &Individual,
-        _rng: &mut dyn RandomGenerator,
+        _rng: &mut impl RandomGenerator,
     ) -> DuelResult {
         // Check feasibility.
         let p1_feasible = p1.is_feasible();
@@ -117,7 +117,8 @@ mod tests {
     }
 
     impl RandomGenerator for FakeRandomGenerator {
-        fn rng(&mut self) -> &mut dyn rand::RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
         fn shuffle_vec_usize(&mut self, _vector: &mut Vec<usize>) {

--- a/moors/src/operators/survival/agemoea.rs
+++ b/moors/src/operators/survival/agemoea.rs
@@ -61,7 +61,7 @@ impl SurvivalOperator for AgeMoeaSurvival {
     fn set_survival_score(
         &self,
         fronts: &mut crate::genetic::Fronts,
-        _rng: &mut dyn RandomGenerator,
+        _rng: &mut impl RandomGenerator,
         _algorithm_context: &AlgorithmContext,
     ) {
         // Split the fronts into the first one and the rest

--- a/moors/src/operators/survival/mod.rs
+++ b/moors/src/operators/survival/mod.rs
@@ -42,7 +42,7 @@ pub trait SurvivalOperator: GeneticOperator {
     fn set_survival_score(
         &self,
         fronts: &mut Fronts,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
         algorithm_context: &AlgorithmContext,
     );
 
@@ -52,7 +52,7 @@ pub trait SurvivalOperator: GeneticOperator {
         &mut self,
         population: Population,
         n_survive: usize,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
         algorithm_context: &AlgorithmContext,
     ) -> Population {
         // Build fronts

--- a/moors/src/operators/survival/nsga2.rs
+++ b/moors/src/operators/survival/nsga2.rs
@@ -27,7 +27,7 @@ impl SurvivalOperator for RankCrowdingSurvival {
     fn set_survival_score(
         &self,
         fronts: &mut Fronts,
-        _rng: &mut dyn RandomGenerator,
+        _rng: &mut impl RandomGenerator,
         _algorithm_context: &AlgorithmContext,
     ) {
         for front in fronts.iter_mut() {

--- a/moors/src/operators/survival/nsga3.rs
+++ b/moors/src/operators/survival/nsga3.rs
@@ -95,7 +95,7 @@ impl SurvivalOperator for Nsga3ReferencePointsSurvival {
     fn set_survival_score(
         &self,
         _fronts: &mut Fronts,
-        _rng: &mut dyn RandomGenerator,
+        _rng: &mut impl RandomGenerator,
         _algorithm_context: &AlgorithmContext,
     ) {
 
@@ -106,7 +106,7 @@ impl SurvivalOperator for Nsga3ReferencePointsSurvival {
         &mut self,
         population: Population,
         n_survive: usize,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
         _algorithm_context: &AlgorithmContext,
     ) -> Population {
         // Build fronts
@@ -274,7 +274,7 @@ fn niching(
     assignments: &Vec<usize>,
     distances: &Vec<f64>,
     splitting_front: &mut Vec<usize>,
-    rng: &mut dyn RandomGenerator,
+    rng: &mut impl RandomGenerator,
 ) -> Vec<usize> {
     // Create available_refs inside the function based on the number of reference points.
     let mut available_refs: Vec<usize> = (0..niche_counts.len()).collect();
@@ -349,7 +349,6 @@ mod tests {
     use super::*;
     use crate::random::{RandomGenerator, TestDummyRng};
     use ndarray::array;
-    use rand::RngCore;
 
     #[test]
     fn test_asf_with_identity_weights() {
@@ -455,7 +454,8 @@ mod tests {
     }
 
     impl RandomGenerator for FakeRandomGenerator {
-        fn rng(&mut self) -> &mut dyn RngCore {
+        type R = TestDummyRng;
+        fn rng(&mut self) -> &mut TestDummyRng {
             &mut self.dummy
         }
         fn choose_usize<'a>(&mut self, vector: &'a [usize]) -> Option<&'a usize> {

--- a/moors/src/operators/survival/revea.rs
+++ b/moors/src/operators/survival/revea.rs
@@ -42,7 +42,7 @@ impl SurvivalOperator for ReveaReferencePointsSurvival {
     fn set_survival_score(
         &self,
         _fronts: &mut crate::genetic::Fronts,
-        _rng: &mut dyn RandomGenerator,
+        _rng: &mut impl RandomGenerator,
         _algorithm_context: &AlgorithmContext,
     ) {
         // REVEA doesn't use fronts. It uses random tournament which doesn't depend on the score"
@@ -52,7 +52,7 @@ impl SurvivalOperator for ReveaReferencePointsSurvival {
         &mut self,
         population: Population,
         _n_survive: usize,
-        _rng: &mut dyn RandomGenerator,
+        _rng: &mut impl RandomGenerator,
         algorithm_context: &AlgorithmContext,
     ) -> Population {
         let z_min = get_ideal(&population.fitness);

--- a/moors/src/operators/survival/rnsga2.rs
+++ b/moors/src/operators/survival/rnsga2.rs
@@ -41,7 +41,7 @@ impl SurvivalOperator for Rnsga2ReferencePointsSurvival {
     fn set_survival_score(
         &self,
         fronts: &mut Fronts,
-        rng: &mut dyn RandomGenerator,
+        rng: &mut impl RandomGenerator,
         _algorithm_context: &AlgorithmContext,
     ) {
         let len_fronts = fronts.len();
@@ -156,7 +156,7 @@ fn distance_to_reference(
 /// - `reference_points`: An Array2<f64> where each row is a reference point.
 /// - `weights`, `ideal`, `nadir`: Parameters used to normalize the distance.
 /// - `epsilon`: The threshold used to group similar solutions.
-/// - `rng`: A mutable reference to an object implementing `RngCore` to be used for random shuffling.
+/// - `rng`: A mutable reference to an object implementing `RandomGenerator` to be used for random shuffling.
 ///
 /// # Returns
 /// A vector of crowding distances (as f64) for each solution.
@@ -177,7 +177,7 @@ fn assign_crowding_distance_splitting_front(
     epsilon: f64,
     nadir: &Array1<f64>,
     ideal: &Array1<f64>,
-    rng: &mut dyn RandomGenerator,
+    rng: &mut impl RandomGenerator,
 ) -> Array1<f64> {
     let num_front_individuals = front_fitness.nrows();
     let mut crowding = assign_crowding_distance_to_inner_front(

--- a/moors/src/random.rs
+++ b/moors/src/random.rs
@@ -8,6 +8,8 @@ use rand::{Rng, RngCore, SeedableRng};
 /// A trait defining a unified interface for generating random values,
 /// used across genetic operators and algorithms.
 pub trait RandomGenerator {
+    type R: RngCore + Rng;
+
     /// Generates a random `usize` in the range `[min, max)` using the underlying RNG.
     fn gen_range_usize(&mut self, min: usize, max: usize) -> usize {
         self.rng().random_range(min..max)
@@ -43,7 +45,7 @@ pub trait RandomGenerator {
         vector.choose(self.rng())
     }
     /// Returns a mutable reference to the underlying RNG implementing `RngCore`.
-    fn rng(&mut self) -> &mut dyn RngCore;
+    fn rng(&mut self) -> &mut Self::R;
 }
 
 /// The production implementation of `RandomGenerator` using `StdRng`.
@@ -64,13 +66,14 @@ impl MOORandomGenerator {
 }
 
 impl RandomGenerator for MOORandomGenerator {
+    type R = StdRng;
     /// Returns a mutable reference to the underlying `StdRng`.
-    fn rng(&mut self) -> &mut dyn RngCore {
+    fn rng(&mut self) -> &mut StdRng {
         &mut self.rng
     }
 }
 
-/// A dummy implementation of `RngCore` for testing purposes.
+/// A dummy implementation of `RandomGenerator` for testing purposes.
 /// This struct is used when methods are called via the `RandomGenerator` trait
 /// without directly interacting with self.rng. This is for testing only, see several
 /// examples in the operators module
@@ -113,7 +116,8 @@ impl NoopRandomGenerator {
 }
 
 impl RandomGenerator for NoopRandomGenerator {
-    fn rng(&mut self) -> &mut dyn RngCore {
+    type R = TestDummyRng;
+    fn rng(&mut self) -> &mut TestDummyRng {
         &mut self.dummy
     }
 }

--- a/moors/tests/test_algorithms_errors.rs
+++ b/moors/tests/test_algorithms_errors.rs
@@ -34,7 +34,7 @@ impl GeneticOperator for NoMutation {
 }
 
 impl MutationOperator for NoMutation {
-    fn mutate<'a>(&self, _individual: IndividualGenesMut<'a>, _rng: &mut dyn RandomGenerator) {
+    fn mutate<'a>(&self, _individual: IndividualGenesMut<'a>, _rng: &mut impl RandomGenerator) {
         // do nothing
     }
 }
@@ -53,7 +53,7 @@ impl CrossoverOperator for NoCrossOver {
         &self,
         parent_a: &IndividualGenes,
         parent_b: &IndividualGenes,
-        _rng: &mut dyn RandomGenerator,
+        _rng: &mut impl RandomGenerator,
     ) -> (IndividualGenes, IndividualGenes) {
         // return parents as children
         (parent_a.clone(), parent_b.clone())


### PR DESCRIPTION
This PR removes the dynamic dispatch for `rng`. The linked issue is #148 