### PR TITLE
Add `Spea2` algorithm and `FrontsAndRankingBasedSurvival` trait for survival operator. Flexibility to use scoring comparison only, in the selector operator 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ moo-rs/
 
 ### Features
 
-- NSGA-II, NSGA-III, R-NSGA-II, Age-MOEA, REVEA (many more coming soon!)
+- NSGA-II, NSGA-III, R-NSGA-II, Age-MOEA, REVEA, SPEA-II (many more coming soon!)
 - Pluggable operators: sampling, crossover, mutation, duplicates removal
 - Flexible fitness & constraints via user-provided closures
 - Built on [ndarray](https://github.com/rust-ndarray/ndarray) and [faer](https://github.com/sarah-quinones/faer-rs)

--- a/moors/Cargo.lock
+++ b/moors/Cargo.lock
@@ -740,9 +740,9 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "log"
@@ -768,7 +768,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "moors"
-version = "0.1.1"
+version = "0.1.2-alpha.0"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -1110,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fb7a99b37aaef4c7dd2fd15a819eb8010bfc7a2c2155230d51f497316cad6d"
+checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/moors/Cargo.toml
+++ b/moors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moors"
-version = "0.1.1"
+version = "0.1.2-alpha.0"
 edition = "2024"
 authors = ["Andrés Sandoval Abarca <andres.sndbrca@gmail.com>"]
 description = "Solving multi-objective optimization problems using genetic algorithms."

--- a/moors/README.md
+++ b/moors/README.md
@@ -10,7 +10,7 @@
 
 ## Features
 
-- NSGA-II, NSGA-III, R-NSGA-II, Age-MOEA, REVEA (many more coming soon!)
+- NSGA-II, NSGA-III, R-NSGA-II, Age-MOEA, REVEA, SPEA-II (many more coming soon!)
 - Pluggable operators: sampling, crossover, mutation, duplicates removal
 - Flexible fitness & constraints via user-provided closures
 - Built on [ndarray](https://github.com/rust-ndarray/ndarray) and [faer](https://github.com/sarah-quinones/faer-rs)

--- a/moors/src/algorithms/agemoea.rs
+++ b/moors/src/algorithms/agemoea.rs
@@ -58,7 +58,7 @@ where
         seed: Option<u64>,
     ) -> Result<Self, MultiObjectiveAlgorithmError> {
         // Define AGEMOEA selector and survivor
-        let selector = RankAndScoringSelection::new();
+        let selector = RankAndScoringSelection::default();
         let survivor = AgeMoeaSurvival::new();
 
         // Build the algorithm.

--- a/moors/src/algorithms/mod.rs
+++ b/moors/src/algorithms/mod.rs
@@ -53,6 +53,7 @@ mod nsga2;
 mod nsga3;
 mod revea;
 mod rnsga2;
+mod spea2;
 
 pub use agemoea::{AgeMoea, AgeMoeaBuilder};
 pub use helpers::error::{InitializationError, MultiObjectiveAlgorithmError};
@@ -60,6 +61,7 @@ pub use nsga2::{Nsga2, Nsga2Builder};
 pub use nsga3::{Nsga3, Nsga3Builder};
 pub use revea::{Revea, ReveaBuilder};
 pub use rnsga2::{Rnsga2, Rnsga2Builder};
+pub use spea2::{Spea2, Spea2Builder};
 
 #[derive(Debug)]
 pub struct MultiObjectiveAlgorithm<S, Sel, Sur, Cross, Mut, F, G, DC>
@@ -181,10 +183,8 @@ where
     }
 
     fn next(&mut self) -> Result<(), MultiObjectiveAlgorithmError> {
-        // Obtain offspring genes.
-
         let ref_pop: &Population = self.population.as_ref().unwrap();
-
+        // Obtain offspring genes.
         let offspring_genes = self
             .evolve
             .evolve(ref_pop, self.context.num_offsprings, 200, &mut self.rng)
@@ -222,7 +222,7 @@ where
         // Create the first Population
         let initial_population = Initialization::initialize(
             &self.sampler,
-            &self.survivor,
+            &mut self.survivor,
             &self.evaluator,
             &self.evolve.duplicates_cleaner,
             &mut self.rng,

--- a/moors/src/algorithms/nsga2.rs
+++ b/moors/src/algorithms/nsga2.rs
@@ -3,7 +3,7 @@ use crate::{
     duplicates::PopulationCleaner,
     genetic::{PopulationConstraints, PopulationFitness, PopulationGenes},
     operators::{
-        CrossoverOperator, FrontsAndRankingBasedSurvival, MutationOperator, SamplingOperator,
+        CrossoverOperator, MutationOperator, SamplingOperator,
         selection::rank_and_survival_scoring_tournament::RankAndScoringSelection,
         survival::nsga2::RankCrowdingSurvival,
     },

--- a/moors/src/algorithms/rnsga2.rs
+++ b/moors/src/algorithms/rnsga2.rs
@@ -5,9 +5,9 @@ use crate::{
     duplicates::PopulationCleaner,
     genetic::{PopulationConstraints, PopulationFitness, PopulationGenes},
     operators::{
-        CrossoverOperator, MutationOperator, SamplingOperator,
+        CrossoverOperator, FrontsAndRankingBasedSurvival, MutationOperator, SamplingOperator,
         selection::rank_and_survival_scoring_tournament::RankAndScoringSelection,
-        survival::rnsga2::Rnsga2ReferencePointsSurvival,
+        survival::{SurvivalScoringComparison, rnsga2::Rnsga2ReferencePointsSurvival},
     },
 };
 
@@ -73,7 +73,9 @@ where
     ) -> Result<Self, MultiObjectiveAlgorithmError> {
         // Define RNSGA2 selector and survivor
         let survivor = Rnsga2ReferencePointsSurvival::new(reference_points, epsilon);
-        let selector = RankAndScoringSelection::new();
+        // RNSGA2 minimizes its scoring survival
+        let selector =
+            RankAndScoringSelection::new(true, true, SurvivalScoringComparison::Minimize);
         // Define inner algorithm
         let algorithm = MultiObjectiveAlgorithm::new(
             sampler,

--- a/moors/src/algorithms/rnsga2.rs
+++ b/moors/src/algorithms/rnsga2.rs
@@ -5,7 +5,7 @@ use crate::{
     duplicates::PopulationCleaner,
     genetic::{PopulationConstraints, PopulationFitness, PopulationGenes},
     operators::{
-        CrossoverOperator, FrontsAndRankingBasedSurvival, MutationOperator, SamplingOperator,
+        CrossoverOperator, MutationOperator, SamplingOperator,
         selection::rank_and_survival_scoring_tournament::RankAndScoringSelection,
         survival::{SurvivalScoringComparison, rnsga2::Rnsga2ReferencePointsSurvival},
     },

--- a/moors/src/genetic.rs
+++ b/moors/src/genetic.rs
@@ -109,6 +109,12 @@ impl Population {
         )
     }
 
+    /// Returns an iterator over all Individuals in this Population.
+    pub fn iter(&self) -> impl Iterator<Item = Individual> + '_ {
+        let n = self.len();
+        (0..n).map(move |i| self.get(i))
+    }
+
     /// Returns a new `Population` containing only the individuals at the specified indices.
     pub fn selected(&self, indices: &[usize]) -> Population {
         let genes = self.genes.select(Axis(0), indices);

--- a/moors/src/helpers/linalg.rs
+++ b/moors/src/helpers/linalg.rs
@@ -1,5 +1,5 @@
 use faer::{Mat, MatRef};
-use faer_ext::IntoFaer;
+use faer_ext::*;
 
 use ndarray::{Array2, ArrayView1, Axis};
 
@@ -56,6 +56,14 @@ pub fn cross_euclidean_distances(data: &Array2<f64>, reference: &Array2<f64>) ->
         data_norm.get(i, 0) + reference_norm.get(j, 0) - 2.0 * faer_dot.get(i, j)
     });
     faer_dist
+}
+
+pub fn cross_euclidean_distances_as_array(
+    data: &Array2<f64>,
+    reference: &Array2<f64>,
+) -> Array2<f64> {
+    let faer_dist = cross_euclidean_distances(data, reference);
+    faer_dist.as_ref().into_ndarray().to_owned()
 }
 
 pub fn cross_p_distances(data: &Array2<f64>, reference: &Array2<f64>, p: f64) -> Array2<f64> {

--- a/moors/src/lib.rs
+++ b/moors/src/lib.rs
@@ -1,3 +1,99 @@
+//! # moors
+//!
+//! <div align="center">
+//! <strong>Multi‑Objective Optimization in Pure Rust</strong><br>
+//! Fast, extensible evolutionary algorithms with first‑class ndarray support.
+//! </div>
+//!
+//! ---
+//!
+//! ## Overview
+//!
+//! `moors` provides a battery of evolutionary algorithms for solving *multi‑objective*
+//! optimization problems.  The core goals are:
+//!
+//! * **Performance** – minimal allocations, Rayon‑powered parallel loops where it matters.
+//! * **Extensibility** – every operator (sampling, crossover, mutation, selection,
+//!   survival) is pluggable via pure Rust traits.
+//!
+//! Currently implemented algorithms
+//!
+//! | Family | Algorithms |
+//! |--------|------------|
+//! | NSGA   | **NSGA‑II**, NSGA‑III, RNSGA‑II |
+//! | SPEA   | SPEA‑2 |
+//! | Others | AGE‑MOEA, REVEA *(WIP)* |
+//!
+//! ## Quick start
+//!
+//! ```rust,no_run
+//! use ndarray::{Array1, Axis, stack};
+//!
+//! use moors::{
+//!     algorithms::{MultiObjectiveAlgorithmError, Nsga2Builder},
+//!     duplicates::ExactDuplicatesCleaner,
+//!     genetic::{PopulationConstraints, PopulationFitness, PopulationGenes},
+//!     operators::{
+//!         crossover::SinglePointBinaryCrossover, mutation::BitFlipMutation,
+//!         sampling::RandomSamplingBinary,
+//!     },
+//! };
+//!
+//! // ----- problem data (0/1 knapsack) -------------------------------------
+//! const WEIGHTS: [f64; 5] = [12.0, 2.0, 1.0, 4.0, 10.0];
+//! const VALUES:  [f64; 5] = [ 4.0, 2.0, 1.0, 5.0,  3.0];
+//! const CAPACITY: f64 = 15.0;
+//!
+//! /// Multi‑objective fitness ⇒ [−total_value, total_weight]
+//! fn fitness(pop_genes: &PopulationGenes) -> PopulationFitness {
+//!     let w = Array1::from_vec(WEIGHTS.into());
+//!     let v = Array1::from_vec(VALUES.into());
+//!     let total_v = pop_genes.dot(&v);
+//!     let total_w = pop_genes.dot(&w);
+//!     stack(Axis(1), &[(-&total_v).view(), total_w.view()]).unwrap()
+//! }
+//!
+//! /// Single inequality constraint ⇒ total_weight − CAPACITY ≤ 0
+//! fn constraints(pop_genes: &PopulationGenes) -> PopulationConstraints {
+//!     let w = Array1::from_vec(WEIGHTS.into());
+//!     (pop_genes.dot(&w) - CAPACITY).insert_axis(Axis(1))
+//! }
+//!
+//! fn main() -> Result<(), MultiObjectiveAlgorithmError> {
+//!     let mut algo = Nsga2Builder::default()
+//!         .fitness_fn(fitness)
+//!         .constraints_fn(constraints)
+//!         .sampler(RandomSamplingBinary::new())
+//!         .crossover(SinglePointBinaryCrossover::new())
+//!         .mutation(BitFlipMutation::new(0.5))
+//!         .duplicates_cleaner(ExactDuplicatesCleaner::new())
+//!         .num_vars(5)
+//!         .num_objectives(2)
+//!         .num_constraints(1)
+//!         .population_size(100)
+//!         .crossover_rate(0.9)
+//!         .mutation_rate(0.1)
+//!         .num_offsprings(32)
+//!         .num_iterations(200)
+//!         .build()?;
+//!
+//!     algo.run()?;
+//!     println!("Final population size: {}", algo.population()?.len());
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Module layout
+//!
+//! * [`algorithms`](crate::algorithms) – high‑level algorithm builders
+//! * [`operators`](crate::operators)  – sampling, crossover, mutation, selection, survival
+//! * [`genetic`](crate::genetic)      – core data types (`Individual`, `Population`, …)
+//! * [`evaluator`](crate::evaluator)  – fitness + constraints evaluation pipeline
+//! * [`random`](crate::random)        – pluggable RNG abstraction
+//! * [`duplicates`](crate::duplicates) – duplicate‑handling strategies
+//!
+//! ---
+
 extern crate core;
 
 pub mod algorithms;

--- a/moors/src/non_dominated_sorting/fds.rs
+++ b/moors/src/non_dominated_sorting/fds.rs
@@ -131,8 +131,8 @@ pub fn fast_non_dominated_sorting(
 }
 
 /// Builds the fronts from the population.
-pub fn build_fronts(population: Population, n_survive: usize) -> Fronts {
-    let sorted_fronts = fast_non_dominated_sorting(&population.fitness, n_survive);
+pub fn build_fronts(population: Population, num_survive: usize) -> Fronts {
+    let sorted_fronts = fast_non_dominated_sorting(&population.fitness, num_survive);
     let mut results: Fronts = Vec::new();
 
     // For each front (with rank = front_index), extract the sub-population.
@@ -291,7 +291,7 @@ mod tests {
         // Build the Population (with rank set to None initially).
         let population = Population::new(genes, fitness, constraints, None);
 
-        // Call build_fronts with n_survive = 5.
+        // Call build_fronts with num_survive = 5.
         let fronts = build_fronts(population, 5);
 
         // We expect three fronts:

--- a/moors/src/non_dominated_sorting/mod.rs
+++ b/moors/src/non_dominated_sorting/mod.rs
@@ -1,4 +1,4 @@
 mod fds;
 
-pub use fds::build_fronts;
+pub(crate) use fds::build_fronts;
 pub use fds::fast_non_dominated_sorting;

--- a/moors/src/operators/mod.rs
+++ b/moors/src/operators/mod.rs
@@ -1,3 +1,81 @@
+//! # `operators` – Building Blocks for Evolution
+//!
+//! Every evolutionary algorithm in **moors** is assembled from a *pipeline* of
+//! interchangeable **operators**.  Each operator focuses on a single stage of
+//! the evolutionary cycle—sampling an initial population, creating offspring,
+//! selecting parents, evaluating diversity, and so on.
+//!
+//! The common super‑trait [`GeneticOperator`] provides a tiny reflection hook
+//! (`name()`) so algorithms and loggers can identify each concrete operator at
+//! runtime.  Beyond that, each sub‑trait defines the behaviour expected for its
+//! stage:
+//!
+//! | Trait | Purpose | Typical Implementations |
+//! |-------|---------|-------------------------|
+//! | [`SamplingOperator`]   | Generate an initial population of genomes. | `RandomSamplingBinary`, `RandomSamplingFloat`, … |
+//! | [`CrossoverOperator`]  | Combine two (or more) parents to create offspring. | `SinglePointBinaryCrossover`, `SimulatedBinaryCrossover`, ... |
+//! | [`MutationOperator`]   | Apply random variation to a single genome *in‑place*. | `BitFlipMutation`, `GaussianMutation`, `ScrambleMutation`, ... |
+//! | [`SelectionOperator`]  | Choose parents via tournaments, fitness‑proportionate schemes, etc. | `RankAndScoringSelection`, `RandomSelection`, ... |
+//! | [`SurvivalOperator`]   | Decide which individuals survive to the next generation. | `FrontsAndRankingBasedSurvival`, `Nsga3ReferencePointsSurvival`, ... |
+//!
+//! ```rust
+//! use moors::{
+//!     genetic::IndividualGenesMut,
+//!     operators::{GeneticOperator, MutationOperator},
+//!     random::RandomGenerator,
+//! };
+//!
+//! /// Flips each binary gene with probability `gene_mutation_rate`.
+//! #[derive(Debug, Clone)]
+//! pub struct MyMutation {
+//!     pub gene_mutation_rate: f64,
+//! }
+//!
+//! impl MyMutation {
+//!     pub fn new(rate: f64) -> Self {
+//!         Self { gene_mutation_rate: rate }
+//!     }
+//! }
+//!
+//! impl GeneticOperator for MyMutation {
+//!     fn name(&self) -> String {
+//!         "MyMutation".into()
+//!     }
+//! }
+//!
+//! impl MutationOperator for MyMutation {
+//!     fn mutate<'a>(
+//!         &self,
+//!         mut individual: IndividualGenesMut<'a>,
+//!         rng: &mut impl RandomGenerator,
+//!     ) {
+//!         for gene in individual.iter_mut() {
+//!             if rng.gen_bool(self.gene_mutation_rate) {
+//!                 *gene = if *gene == 0.0 { 1.0 } else { 0.0 };
+//!             }
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! Once compiled, you can pass `MyMutation` into any `*Builder` just like the
+//! built‑in operators.
+//!
+//! ## Module layout
+//!
+//! * [`crossover`]   – crossover operators
+//! * [`mutation`]    – mutation operators
+//! * [`sampling`]    – initial population generators
+//! * [`selection`]   – parent‑selection strategies
+//! * [`survival`]    – survival / environmental‑selection strategies
+//! * [`evolve`]      – glue code to run *selection → crossover → mutation*
+//!
+//! ---
+//!
+//! **Tip:** Because every operator is trait‑based, you can unit‑test them in
+//! isolation or swap them at runtime to benchmark different evolutionary
+//! dynamics without touching your problem‑specific code or algorithm builder.
+
 use std::fmt::Debug;
 
 pub mod crossover;
@@ -12,7 +90,7 @@ pub use evolve::{Evolve, EvolveError};
 pub use mutation::MutationOperator;
 pub use sampling::SamplingOperator;
 pub use selection::SelectionOperator;
-pub use survival::SurvivalOperator;
+pub use survival::{FrontsAndRankingBasedSurvival, SurvivalOperator};
 
 pub trait GeneticOperator: Debug {
     fn name(&self) -> String;

--- a/moors/src/operators/survival/agemoea.rs
+++ b/moors/src/operators/survival/agemoea.rs
@@ -8,10 +8,10 @@ use crate::algorithms::helpers::context::AlgorithmContext;
 use crate::genetic::PopulationFitness;
 use crate::helpers::extreme_points::get_ideal;
 use crate::helpers::linalg::{cross_p_distances, lp_norm_arrayview};
-use crate::operators::{
-    GeneticOperator, SurvivalOperator, survival::helpers::HyperPlaneNormalization,
-};
+use crate::operators::{GeneticOperator, survival::helpers::HyperPlaneNormalization};
 use crate::random::RandomGenerator;
+
+use super::FrontsAndRankingBasedSurvival;
 
 struct AgeMoeaHyperPlaneNormalization;
 
@@ -57,8 +57,8 @@ impl AgeMoeaSurvival {
     }
 }
 
-impl SurvivalOperator for AgeMoeaSurvival {
-    fn set_survival_score(
+impl FrontsAndRankingBasedSurvival for AgeMoeaSurvival {
+    fn set_front_survival_score(
         &self,
         fronts: &mut crate::genetic::Fronts,
         _rng: &mut impl RandomGenerator,
@@ -474,19 +474,19 @@ mod tests {
         let genes = fitness.clone();
         let population = Population::new(genes, fitness, None, None);
         // Set the desired number of survivors (e.g., 4).
-        let n_survive = 4;
+        let num_survive = 4;
 
         let mut operator = AgeMoeaSurvival::new();
         let mut rng = NoopRandomGenerator::new();
         // create context (not used in the algorithm)
         let _context = AlgorithmContext::new(2, 5, 5, 2, 1, 0, None, None);
-        let survivors = operator.operate(population, n_survive, &mut rng, &_context);
+        let survivors = operator.operate(population, num_survive, &mut rng, &_context);
 
         assert_eq!(
             survivors.len(),
-            n_survive,
+            num_survive,
             "Expected {} survivors, got {}",
-            n_survive,
+            num_survive,
             survivors.len()
         )
     }

--- a/moors/src/operators/survival/revea.rs
+++ b/moors/src/operators/survival/revea.rs
@@ -6,7 +6,7 @@ use crate::algorithms::helpers::context::AlgorithmContext;
 use crate::genetic::Population;
 use crate::helpers::extreme_points::{get_ideal, get_nadir};
 use crate::helpers::linalg::{faer_dot_and_norms, faer_dot_from_array};
-use crate::operators::{GeneticOperator, SurvivalOperator};
+use crate::operators::{GeneticOperator, survival::SurvivalOperator};
 use crate::random::RandomGenerator;
 
 /// Implementation of the survival operator for the REVEA algorithm presented in the paper
@@ -39,15 +39,6 @@ impl ReveaReferencePointsSurvival {
 }
 
 impl SurvivalOperator for ReveaReferencePointsSurvival {
-    fn set_survival_score(
-        &self,
-        _fronts: &mut crate::genetic::Fronts,
-        _rng: &mut impl RandomGenerator,
-        _algorithm_context: &AlgorithmContext,
-    ) {
-        // REVEA doesn't use fronts. It uses random tournament which doesn't depend on the score"
-    }
-
     fn operate(
         &mut self,
         population: Population,

--- a/moors/src/operators/survival/rnsga2.rs
+++ b/moors/src/operators/survival/rnsga2.rs
@@ -6,7 +6,9 @@ use ndarray::{Array1, Array2, ArrayView1, Axis};
 use crate::algorithms::helpers::context::AlgorithmContext;
 use crate::genetic::{Fronts, PopulationFitness};
 use crate::helpers::extreme_points::{get_ideal, get_nadir};
-use crate::operators::survival::{GeneticOperator, SurvivalOperator, SurvivalScoringComparison};
+use crate::operators::survival::{
+    FrontsAndRankingBasedSurvival, GeneticOperator, SurvivalScoringComparison,
+};
 use crate::random::RandomGenerator;
 
 /// Implementation of the survival operator for the R-NSGA2 algorithm presented in the paper
@@ -33,12 +35,12 @@ impl Rnsga2ReferencePointsSurvival {
     }
 }
 
-impl SurvivalOperator for Rnsga2ReferencePointsSurvival {
+impl FrontsAndRankingBasedSurvival for Rnsga2ReferencePointsSurvival {
     fn scoring_comparison(&self) -> SurvivalScoringComparison {
         SurvivalScoringComparison::Minimize
     }
 
-    fn set_survival_score(
+    fn set_front_survival_score(
         &self,
         fronts: &mut Fronts,
         rng: &mut impl RandomGenerator,

--- a/moors/src/operators/survival/spea2.rs
+++ b/moors/src/operators/survival/spea2.rs
@@ -1,0 +1,399 @@
+use std::cmp::Ordering;
+
+use ndarray::{Array1, Array2, Axis};
+
+use crate::algorithms::helpers::context::AlgorithmContext;
+use crate::genetic::{Population, PopulationFitness};
+use crate::helpers::linalg::cross_euclidean_distances_as_array;
+use crate::non_dominated_sorting::fast_non_dominated_sorting;
+use crate::operators::{GeneticOperator, SurvivalOperator};
+use crate::random::RandomGenerator;
+
+#[derive(Debug, Clone)]
+pub struct Spea2KnnSurvival;
+
+impl GeneticOperator for Spea2KnnSurvival {
+    fn name(&self) -> String {
+        "Spea2KnnSurvival".into()
+    }
+}
+
+impl Spea2KnnSurvival {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl SurvivalOperator for Spea2KnnSurvival {
+    fn operate(
+        &mut self,
+        population: Population,
+        num_survive: usize,
+        _rng: &mut impl RandomGenerator,
+        _algorithm_context: &AlgorithmContext,
+    ) -> Population {
+        // Compute raw fitness F(i) = R(i) + D(i)
+        let k = population.len().isqrt();
+        let distance_matrix =
+            cross_euclidean_distances_as_array(&population.fitness, &population.fitness);
+        let density = compute_density(&distance_matrix, k);
+        let domination_indices = compute_domination_indices(&population.fitness);
+        // raw_fitness[i] = domination_indices_f[i] + density[i]
+        let raw_fitness: Array1<f64> = &domination_indices + &density;
+        // Next step is to check out if the |{i: S(i) < 1}| = {i: raw_fitness[i] < 1}| <= num_survive
+        let mut s: Vec<usize> = raw_fitness
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &f)| if f < 1.0 { Some(i) } else { None })
+            .collect();
+        // Branch based on S.len() vs num_survive
+        match s.len().cmp(&num_survive) {
+            Ordering::Equal => {
+                // Case A: exactly the right number — nothing to do
+                // `s` already has the survivors
+            }
+            Ordering::Less => {
+                // Case B: too few non-dominated solutions — fill with best of the rest
+                let needed = num_survive - s.len();
+                let dominated_indices = select_dominated(&raw_fitness, needed);
+                s.extend(dominated_indices);
+            }
+            Ordering::Greater => {
+                // Case C: too many non-dominated
+                s = select_by_nearest_neighbor(&distance_matrix, num_survive);
+            }
+        }
+        let mut survivors = population.selected(&s);
+        // Assign the score
+        let selected_scores: Array1<f64> = raw_fitness.select(Axis(0), &s);
+        // ignore Result
+        _ = survivors.set_survival_score(selected_scores);
+        survivors
+    }
+}
+
+/// Compute density D(i) = 1 / (σᵢᵏ + 2) for each individual i,
+/// where σᵢᵏ is the k-th smallest distance in row i (including the zero at index 0).
+///
+/// # Arguments
+/// * `distance_matrix` – an n×n Array2<f64> of pairwise distances (diagonal == 0).
+/// * `k` – neighbor index: 0 gives σ⁰=0 (self), so to pick the 1st real neighbor use k=1, etc.
+pub fn compute_density(distance_matrix: &Array2<f64>, k: usize) -> Array1<f64> {
+    let n = distance_matrix.nrows();
+
+    let mut densities = Array1::<f64>::zeros(n);
+
+    for i in 0..n {
+        // TODO: Can we avoid cloning or passing to a Vec?
+        // Ivestigate this ndarray method: select_nth_unstable_by
+        let mut dists: Vec<f64> = distance_matrix.row(i).iter().cloned().collect();
+        dists.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        // σᵢᵏ is at index k. Note that in the position 0
+        // we have d = 0, because in the sorted it's distance between
+        // the individual with itself. So we use k instead of k-1
+        let sigma_k = dists[k];
+        // Compute density
+        densities[i] = 1.0 / (sigma_k + 2.0);
+    }
+
+    densities
+}
+
+/// Compute the Pareto-domination index for each individual in the population.
+///
+/// Given an (N×M) fitness matrix, returns a length-N `Array1<usize>` where the
+/// i-th entry is the zero-based non-domination rank of individual i:
+/// - 0 for those not dominated by anyone,
+/// - 1 for those only dominated by rank-0 individuals,
+/// - 2 for those dominated by rank-0 and rank-1, and so on.
+///
+/// Internally this calls `fast_non_dominated_sorting(..., N)` to partition
+/// all individuals into successive non-dominated sets, then assigns each
+/// individual the index of the set it belongs to.
+pub fn compute_domination_indices(population_fitness: &PopulationFitness) -> Array1<f64> {
+    let n = population_fitness.nrows();
+    let ranks = fast_non_dominated_sorting(population_fitness, n);
+
+    let mut domination_indices = Array1::<f64>::zeros(n);
+
+    for (rank, group) in ranks.into_iter().enumerate() {
+        for &i in &group {
+            domination_indices[i] = rank as f64;
+        }
+    }
+
+    domination_indices
+}
+
+/// Select the top `r` dominated individuals (those with `raw_fitness >= 1.0`)
+/// by ascending raw fitness (i.e. smallest F(i) first).
+///
+/// # Arguments
+///
+/// * `raw_fitness` – an Array1<f64> of length N containing each individual’s F(i).
+/// * `r` – the number of dominated individuals to return.
+///
+/// # Returns
+///
+/// A `Vec<usize>` of length `r`, containing the indices of the dominated
+/// individuals with the smallest raw_fitness values, in ascending order.
+pub fn select_dominated(raw_fitness: &Array1<f64>, r: usize) -> Vec<usize> {
+    // Collect all (index, fitness) for dominated individuals
+    let mut dominated: Vec<(usize, f64)> = raw_fitness
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &f)| if f >= 1.0 { Some((i, f)) } else { None })
+        .collect();
+
+    // Sort by fitness ascending (best dominated first)
+    dominated.sort_unstable_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Equal));
+
+    // Take the first `r` indices
+    dominated.into_iter().take(r).map(|(idx, _)| idx).collect()
+}
+
+/// Selects the `r` most isolated individuals from an n×n distance matrix,
+/// by looking at each row’s *nearest neighbor* distance (excluding self).
+///
+/// # Arguments
+///
+/// * `distance_matrix` – an n×n square matrix of pairwise distances (diagonal = 0).
+/// * `r` – number of survivors to pick (0 ≤ r ≤ n).
+///
+/// # Returns
+///
+/// A `Vec<usize>` of length `r` containing the row indices of the selected survivors.
+pub fn select_by_nearest_neighbor(distance_matrix: &Array2<f64>, r: usize) -> Vec<usize> {
+    let n = distance_matrix.nrows();
+    // 1) Compute each row’s nearest‐neighbor distance (excluding the diagonal entry)
+    //    Store (index, nearest_dist) pairs.
+    let mut nearest: Vec<(usize, f64)> = Vec::with_capacity(n);
+    for i in 0..n {
+        // Find the minimum over all j != i
+        let min_dist = distance_matrix
+            .row(i)
+            .iter()
+            .enumerate()
+            .filter_map(|(j, &d)| if j != i { Some(d) } else { None })
+            .fold(f64::INFINITY, f64::min);
+        nearest.push((i, min_dist));
+    }
+
+    // 2) Sort by nearest_dist **descending**:
+    //    individuals with larger nearest‐neighbor distance are more isolated.
+    nearest.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+
+    // 3) Take the top `r` indices
+    nearest.into_iter().take(r).map(|(idx, _)| idx).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    use crate::random::NoopRandomGenerator;
+
+    #[test]
+    fn test_compute_density() {
+        // 4×4 distance matrix (symmetric, diagonal = 0), columns not sorted:
+        //
+        //    0   5   2   8
+        //    5   0   9   1
+        //    2   9   0   4
+        //    8   1   4   0
+        //
+        // For n = 4 → k = floor(sqrt(4)) = 2
+        // Row 0 sorted distances: [0,2,5,8] → σ₂ = 5 → D₀ = 1/(5 + 2) = 1/7
+        // Row 1 sorted distances: [0,1,5,9] → σ₂ = 5 → D₁ = 1/7
+        // Row 2 sorted distances: [0,2,4,9] → σ₂ = 4 → D₂ = 1/6
+        // Row 3 sorted distances: [0,1,4,8] → σ₂ = 4 → D₃ = 1/6
+
+        let dm = array![
+            [0.0, 5.0, 2.0, 8.0],
+            [5.0, 0.0, 9.0, 1.0],
+            [2.0, 9.0, 0.0, 4.0],
+            [8.0, 1.0, 4.0, 0.0],
+        ];
+
+        let densities = compute_density(&dm, 2);
+        let expected = [1.0 / 7.0, 1.0 / 7.0, 1.0 / 6.0, 1.0 / 6.0];
+
+        for i in 0..4 {
+            assert!(
+                (densities[i] - expected[i]).abs() < 1e-12,
+                "density[{}] = {}, but expected {}",
+                i,
+                densities[i],
+                expected[i]
+            );
+        }
+    }
+
+    #[test]
+    fn test_select_dominated_mixed() {
+        // raw_fitness contains values <1.0 and >=1.0
+        // only those >=1.0 should be considered dominated
+        // raw = [0.5, 1.0, 2.0, 3.0, 1.5]
+        // dominated candidates = (1,1.0), (2,2.0), (3,3.0), (4,1.5)
+        // sorted ascending by fitness: (1,1.0), (4,1.5), (2,2.0), (3,3.0)
+        // take r=3 → indices [1, 4, 2]
+        let raw: Array1<f64> = array![0.5, 1.0, 2.0, 3.0, 1.5];
+        let picked = select_dominated(&raw, 3);
+        assert_eq!(picked, vec![1, 4, 2]);
+    }
+
+    #[test]
+    fn test_select_dominated_all() {
+        // raw_fitness all >1.0
+        // raw = [1.1, 2.2, 3.3]
+        // sorted ascending: (0,1.1), (1,2.2), (2,3.3)
+        // take r=2 → indices [0, 1]
+        let raw: Array1<f64> = array![1.1, 2.2, 3.3];
+        let picked = select_dominated(&raw, 2);
+        assert_eq!(picked, vec![0, 1]);
+    }
+
+    #[test]
+    fn test_chain_dominance() {
+        // A simple chain: A dominates B, B dominates C.
+        // Fitness vectors: A = [1,1], B = [2,2], C = [3,3]
+        // Expected ranks: A → 0, B → 1, C → 2
+        let fitness: PopulationFitness = array![[1.0, 1.0], [2.0, 2.0], [3.0, 3.0],];
+        let indices = compute_domination_indices(&fitness);
+        assert_eq!(indices.len(), 3);
+        assert_eq!(indices, array![0.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_no_dominance_all_zero() {
+        // All are non-dominated pairwise: rank 0 for everyone
+        // Fitness: [1,4], [2,3], [3,2], [4,1]
+        let fitness: PopulationFitness = array![[1.0, 4.0], [2.0, 3.0], [3.0, 2.0], [4.0, 1.0],];
+        let indices = compute_domination_indices(&fitness);
+        assert_eq!(indices.len(), 4);
+        assert_eq!(indices, array![0.0, 0.0, 0.0, 0.0]);
+    }
+
+    /// Helper: build a Population from raw fitness only.
+    /// We use a dummy 1-column gene matrix and no constraints or rank.
+    fn make_population(fitness: Array2<f64>) -> Population {
+        let n = fitness.nrows();
+        // 1 variable per individual, value zero—genes are never used by survival
+        let genes = Array2::<f64>::zeros((n, 1));
+        Population {
+            genes,
+            fitness,
+            constraints: None,
+            rank: None,
+            survival_score: None,
+        }
+    }
+
+    #[test]
+    fn test_fills_when_underflow() {
+        // Define objective fitness = [0.5, 1.2, 1.5]
+        let fit = array![[0.5], [1.2], [1.5]];
+        let pop = make_population(fit.clone());
+
+        // Manually compute the **raw fitness** using squared distances:
+        //
+        // Note that in our code we use the squared distance, we don't take square root
+        // This is a simple test case for a single objecive, where squared distance might
+        // not make sense
+
+        //    - n = 3  ⇒ k = floor(sqrt(3)) = 1
+        //    - Squared‐distance matrix:
+        //        [0,      0.49,   1.00]
+        //        [0.49,   0.00,   0.09]
+        //        [1.00,   0.09,   0.00]
+        //
+        //      Row0 sorted: [0, 0.49, 1.00] → σ₁ = 0.49 → D₀ = 1/(0.49+2) ≈ 0.4016064
+        //      Row1 sorted: [0, 0.09, 0.49] → σ₁ = 0.09 → D₁ = 1/(0.09+2) ≈ 0.4784689
+        //      Row2 sorted: [0, 0.09, 1.00] → σ₁ = 0.09 → D₂ = 1/(0.09+2) ≈ 0.4784689
+        //
+        //    - Pareto‐ranks R(i):
+        //        0.5 dominates {1.2,1.5} → R₀=0
+        //        1.2 dominates {1.5}     → R₁=1
+        //        1.5 dominated twice     → R₂=2
+        //
+        //    - So raw_fitness = R + D:
+        //        F₀ = 0 + 0.4016064  ≈ 0.4016064
+        //        F₁ = 1 + 0.4784689  ≈ 1.4784689
+        //        F₂ = 2 + 0.4784689  ≈ 2.4784689
+        let expected_raw = [0.4016064, 1.4784689, 2.4784689];
+
+        // 3) Run operate with capacity = 2
+        let mut rng = NoopRandomGenerator::new();
+        let ctx = AlgorithmContext::new(10, 10, 5, 1, 1, 0, None, None);
+        let survivors = Spea2KnnSurvival::new().operate(pop, 2, &mut rng, &ctx);
+
+        // 4) Extract survivors’ survival_score fields
+        let scores: Vec<f64> = survivors
+            .survival_score
+            .as_ref()
+            .expect("survival_score must be set")
+            .to_vec();
+
+        // 5) Underflow picks indices 0 and 1, so we expect
+        //    [expected_raw[0], expected_raw[1]]
+        assert_eq!(scores.len(), 2);
+        assert!((scores[0] - expected_raw[0]).abs() < 1e-6,);
+        assert!((scores[1] - expected_raw[1]).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_overflow_keeps_first_two_when_all_tie() {
+        // Four pair‑wise non‑dominated points:
+        //   #0 (0,3)   #1 (1,2)   #2 (2,1)   #3 (3,0)
+        let fit = array![[0.0, 3.0], [1.0, 2.0], [2.0, 1.0], [3.0, 0.0],];
+        let pop = make_population(fit.clone());
+
+        // Capacity = 2 → overflow branch
+        let mut rng = NoopRandomGenerator::new();
+        let ctx = AlgorithmContext::new(10, 10, 5, 2, 2, 0, None, None);
+        let survivors = Spea2KnnSurvival::new().operate(pop, 2, &mut rng, &ctx);
+
+        // Expect exactly two survivors
+        assert_eq!(survivors.len(), 2);
+
+        // They must correspond to indices 0 and 1 (original order)
+        assert_eq!(survivors.get(0).fitness.to_vec(), vec![0.0, 3.0]);
+        assert_eq!(survivors.get(1).fitness.to_vec(), vec![1.0, 2.0]);
+
+        // Expected raw‑fitness (R+ D with squared distances, k=2):
+        //    row0 σ₂ = 8  → D0 = 1/10 = 0.1
+        //    row1 σ₂ = 2  → D1 = 1/4  = 0.25
+        let expected = [0.1, 0.25];
+
+        let scores = survivors
+            .survival_score
+            .as_ref()
+            .expect("survival_score must be set");
+
+        // Order is deterministic (indices 0 then 1)
+        assert_eq!(scores.len(), 2);
+        assert!((scores[0] - expected[0]).abs() < 1e-6);
+        assert!((scores[1] - expected[1]).abs() < 1e-6);
+    }
+
+    #[test]
+    fn all_survive_when_capacity_equals_population() {
+        // Same four pair‑wise non‑dominated points as before
+        let fit = array![
+            [0.0, 3.0], // #0
+            [1.0, 2.0], // #1
+            [2.0, 1.0], // #2
+            [3.0, 0.0], // #3
+        ];
+        let pop = make_population(fit.clone());
+
+        // Capacity exactly equals population size (4) → no truncation
+        let mut rng = NoopRandomGenerator::new();
+        let ctx = AlgorithmContext::new(10, 10, 5, 4, 2, 0, None, None);
+        let survivors = Spea2KnnSurvival::new().operate(pop, 4, &mut rng, &ctx);
+
+        // all individuals must survive
+        assert_eq!(survivors.len(), 4);
+    }
+}

--- a/moors/tests/tests_algorithms_generic.rs
+++ b/moors/tests/tests_algorithms_generic.rs
@@ -3,7 +3,9 @@ use ordered_float::OrderedFloat;
 use std::collections::HashSet;
 
 use moors::{
-    algorithms::{AgeMoeaBuilder, Nsga2Builder, Nsga3Builder, ReveaBuilder, Rnsga2Builder},
+    algorithms::{
+        AgeMoeaBuilder, Nsga2Builder, Nsga3Builder, ReveaBuilder, Rnsga2Builder, Spea2Builder,
+    },
     duplicates::CloseDuplicatesCleaner,
     genetic::{FitnessFn, NoConstraintsFn, Population, PopulationFitness, PopulationGenes},
     operators::{
@@ -206,6 +208,37 @@ fn test_revea() {
         .expect("failed to build REVEA");
 
     algorithm.run().expect("Revea run failed");
+    let population = algorithm
+        .population()
+        .expect("population should have been initialized");
+    assert_small_real_front(&population);
+}
+
+#[test]
+#[should_panic] // The algorithm is not reaching the expected performance. Needs investigation
+fn test_spea2() {
+    let mut algorithm = Spea2Builder::<_, _, _, _, NoConstraintsFn, _>::default()
+        .sampler(RandomSamplingFloat::new(0.0, 1.0))
+        .crossover(SimulatedBinaryCrossover::new(15.0))
+        .mutation(GaussianMutation::new(0.5, 0.01))
+        .duplicates_cleaner(CloseDuplicatesCleaner::new(1e-6))
+        .fitness_fn(fitness_biobjective as FitnessFn)
+        .num_vars(2)
+        .num_objectives(2)
+        .population_size(200)
+        .num_offsprings(200)
+        .num_iterations(100)
+        .mutation_rate(0.1)
+        .crossover_rate(0.9)
+        .keep_infeasible(false)
+        .verbose(true)
+        .lower_bound(0.0)
+        .upper_bound(1.0)
+        .seed(42)
+        .build()
+        .expect("failed to build SPEA2");
+
+    algorithm.run().expect("SPEA2 run failed");
     let population = algorithm
         .population()
         .expect("population should have been initialized");


### PR DESCRIPTION
This PR adds #155  and also starts the work on #157 in order to cover more cases.  Added `FrontsAndRankingBasedSurvival` trait for algorithms that uses fronts and scoring metrcis, such as NSGA2, AGEMOEA, etc and keep the minimal trait `SurvivalOperator` for more generic algorithms, such as SPEA2