### PR TITLE
Add `thiserror` crate for error defs

### DIFF
--- a/moors/Cargo.lock
+++ b/moors/Cargo.lock
@@ -783,6 +783,7 @@ dependencies = [
  "rand_distr 0.5.1",
  "rayon",
  "rstest",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/moors/Cargo.toml
+++ b/moors/Cargo.toml
@@ -22,6 +22,7 @@ ndarray-stats = "0.6.0"
 faer-ext = { version = "0.5.0", features = ["ndarray"] }
 faer = "0.21.9"
 moors_macros = { version = "0.1.0", path = "moors_macros"}
+thiserror = "2.0.12"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/moors/src/algorithms/helpers/error.rs
+++ b/moors/src/algorithms/helpers/error.rs
@@ -1,89 +1,32 @@
-use std::{error::Error, fmt};
+use thiserror::Error;
 
 use crate::evaluator::EvaluatorError;
-use crate::operators::EvolveError;
+use crate::operators::evolve::EvolveError;
 
 /// Errors that can occur during initialization of the population.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum InitializationError {
     /// Error from the evaluator.
-    Evaluator(EvaluatorError),
+    #[error("Error during evaluation at initialization: {0}")]
+    Evaluator(#[from] EvaluatorError),
     /// Fitness array length does not match number of objectives.
+    #[error("Invalid fitness setup: {0}")]
     InvalidFitness(String),
-    /// Constraints array length mismatch or unexpected absence.
+    #[error("Invalid constraints setup: {0}")]
     InvalidConstraints(String),
-    /// Trying to access to algorithm attributes set after initialization
+    /// Constraints array length mismatch or unexpected absence.
+    #[error("Algorithm is not initialized yet: {0}")]
     NotInitializated(String),
 }
 
-impl fmt::Display for InitializationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            InitializationError::Evaluator(e) => {
-                write!(f, "Error during evaluation in initialization: {}", e)
-            }
-            InitializationError::InvalidFitness(msg) => write!(f, "Invalid fitness setup: {}", msg),
-            InitializationError::InvalidConstraints(msg) => {
-                write!(f, "Invalid constraints setup: {}", msg)
-            }
-            InitializationError::NotInitializated(msg) => {
-                write!(f, "Algorithm is not initialized yet: {}", msg)
-            }
-        }
-    }
-}
-
-impl From<EvaluatorError> for InitializationError {
-    fn from(e: EvaluatorError) -> Self {
-        InitializationError::Evaluator(e)
-    }
-}
-
-impl Error for InitializationError {}
-
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum MultiObjectiveAlgorithmError {
-    Evolve(EvolveError),
-    Evaluator(EvaluatorError),
+    #[error("Error during evolution: {0}")]
+    Evolve(#[from] EvolveError),
+    #[error("Error during evaluation: {0}")]
+    Evaluator(#[from] EvaluatorError),
+    #[error("Invalid parameter: {0}")]
     InvalidParameter(String),
-    Initialization(InitializationError),
+    #[error("Error during onitialization: {0}")]
+    Initialization(#[from] InitializationError),
 }
-
-impl fmt::Display for MultiObjectiveAlgorithmError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            MultiObjectiveAlgorithmError::Evolve(msg) => {
-                write!(f, "Error during evolution: {}", msg)
-            }
-            MultiObjectiveAlgorithmError::Evaluator(msg) => {
-                write!(f, "Error during evaluation: {}", msg)
-            }
-            MultiObjectiveAlgorithmError::InvalidParameter(msg) => {
-                write!(f, "Invalid parameter: {}", msg)
-            }
-            MultiObjectiveAlgorithmError::Initialization(msg) => {
-                write!(f, "Error during initialization: {}", msg)
-            }
-        }
-    }
-}
-
-impl From<EvolveError> for MultiObjectiveAlgorithmError {
-    fn from(e: EvolveError) -> Self {
-        MultiObjectiveAlgorithmError::Evolve(e)
-    }
-}
-
-impl From<EvaluatorError> for MultiObjectiveAlgorithmError {
-    fn from(e: EvaluatorError) -> Self {
-        MultiObjectiveAlgorithmError::Evaluator(e)
-    }
-}
-
-impl From<InitializationError> for MultiObjectiveAlgorithmError {
-    fn from(e: InitializationError) -> Self {
-        MultiObjectiveAlgorithmError::Initialization(e)
-    }
-}
-
-impl Error for MultiObjectiveAlgorithmError {}

--- a/moors/src/algorithms/mod.rs
+++ b/moors/src/algorithms/mod.rs
@@ -337,11 +337,9 @@ where
                         );
                     }
                 }
-                Err(MultiObjectiveAlgorithmError::Evolve(EvolveError::EmptyMatingResult {
-                    message,
-                    ..
-                })) => {
-                    println!("Warning: {}. Terminating the algorithm early.", message);
+                Err(MultiObjectiveAlgorithmError::Evolve(err @ EvolveError::EmptyMatingResult)) => {
+                    // `err` implementa Display → produce el mensaje
+                    println!("Warning: {}. Terminating the algorithm early.", err);
                     break;
                 }
                 Err(e) => return Err(e),

--- a/moors/src/evaluator.rs
+++ b/moors/src/evaluator.rs
@@ -4,25 +4,16 @@
 //! and constraints functions) meets the core data structures of *moors*.  It
 //! takes a 2‑D array of genomes (`PopulationGenes` = `Array2<f64>`) and returns
 //! a fully populated [`Population`] with fitness values and optional constraints
+use ndarray::Axis;
+use thiserror::Error;
 
 use crate::genetic::{Population, PopulationConstraints, PopulationFitness, PopulationGenes};
-use ndarray::Axis;
-use std::fmt;
 
 /// Error type for the Evaluator.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum EvaluatorError {
+    #[error("No feasible individuals found in the population.")]
     NoFeasibleIndividuals,
-}
-
-impl fmt::Display for EvaluatorError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            EvaluatorError::NoFeasibleIndividuals => {
-                write!(f, "No feasible individuals found in the population.")
-            }
-        }
-    }
 }
 
 /// Evaluator struct for calculating fitness and (optionally) constraints,

--- a/moors/src/operators/evolve.rs
+++ b/moors/src/operators/evolve.rs
@@ -1,5 +1,6 @@
-use std::fmt;
 use std::fmt::Debug;
+
+use thiserror::Error;
 
 use crate::{
     duplicates::PopulationCleaner,
@@ -26,31 +27,10 @@ where
     upper_bound: Option<f64>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Error)]
 pub enum EvolveError {
-    EmptyMatingResult {
-        message: String,
-        current_offspring_count: usize,
-        required_offsprings: usize,
-    },
-}
-
-impl fmt::Display for EvolveError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            EvolveError::EmptyMatingResult {
-                message,
-                current_offspring_count,
-                required_offsprings,
-            } => {
-                write!(
-                    f,
-                    "{} (generated offsprings: {}, required: {})",
-                    message, current_offspring_count, required_offsprings
-                )
-            }
-        }
-    }
+    #[error("No offsprings were generated in the mating process")]
+    EmptyMatingResult,
 }
 
 impl<Sel, Cross, Mut, DC> Evolve<Sel, Cross, Mut, DC>
@@ -181,11 +161,7 @@ where
         }
 
         if all_offsprings.is_empty() {
-            return Err(EvolveError::EmptyMatingResult {
-                message: "No offspring were generated.".to_string(),
-                current_offspring_count: 0,
-                required_offsprings: num_offsprings,
-            });
+            return Err(EvolveError::EmptyMatingResult);
         }
 
         // Convert Vec<Vec<f64>> into a single Array2.

--- a/moors/tests/test_algorithms_errors.rs
+++ b/moors/tests/test_algorithms_errors.rs
@@ -169,7 +169,7 @@ fn test_no_feasible_in_initialization() {
             let msg = inner.to_string();
             assert_eq!(
                 msg,
-                "Error during evaluation in initialization: No feasible individuals found in the population.",
+                "Error during evaluation at initialization: No feasible individuals found in the population.",
             );
         }
         other => panic!("Incorrect error raised: {:?}", other),


### PR DESCRIPTION
Partially completed #174 --- I did not want to return `Result<T,E>` in operators because there are not much `expect` calls