### PR TITLE
Remove context from operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ moo-rs/
 
 ```toml
 [dependencies]
-moors = "0.2.2"
+moors = "0.2.3"
 ```
 
 ### Quickstart

--- a/moors/Cargo.lock
+++ b/moors/Cargo.lock
@@ -846,7 +846,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "moors"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",

--- a/moors/Cargo.toml
+++ b/moors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moors"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 authors = ["Andrés Sandoval Abarca <andres.sndbrca@gmail.com>"]
 description = "Solving multi-objective optimization problems using genetic algorithms."

--- a/moors/README.md
+++ b/moors/README.md
@@ -22,7 +22,7 @@
 
 ```toml
 [dependencies]
-moors = "0.2.2"
+moors = "0.2.3"
 ```
 
 ## Quickstart

--- a/moors/src/algorithms/builder.rs
+++ b/moors/src/algorithms/builder.rs
@@ -255,7 +255,6 @@ where
             evaluated_population,
             self.context.population_size,
             &mut self.rng,
-            &self.context,
         );
         // Update the population attribute
         self.population = Some(survivors);

--- a/moors/src/algorithms/helpers/initialization.rs
+++ b/moors/src/algorithms/helpers/initialization.rs
@@ -39,7 +39,7 @@ impl Initialization {
         // we use num_survive = context.population_size, but this step is adding the ranking
         // and the survival scorer (if the algorithm needs them), so in the selection step
         // we have all we need. See: https://github.com/andresliszt/moo-rs/issues/145
-        population = survivor.operate(population, context.population_size, rng, &context);
+        population = survivor.operate(population, context.population_size, rng);
         Ok(population)
     }
 }

--- a/moors/src/algorithms/mod.rs
+++ b/moors/src/algorithms/mod.rs
@@ -12,5 +12,4 @@ pub use moo::revea::{Revea, ReveaBuilder};
 pub use moo::rnsga2::{Rnsga2, Rnsga2Builder};
 pub use moo::spea2::{Spea2, Spea2Builder};
 
-pub(crate) use helpers::AlgorithmContext;
 pub use helpers::{AlgorithmError, InitializationError};

--- a/moors/src/algorithms/moo/revea.rs
+++ b/moors/src/algorithms/moo/revea.rs
@@ -47,8 +47,8 @@ create_algorithm!(
     ///   pp. 773–791, Oct. 2016.
     ///   DOI: 10.1109/TEVC.2015.2495854
     ///
-    /// Build via [`ReveaBuilder`](crate::algorithms::ReveaBuilder) or directly with
-    /// [`Revea::new`], then call `run()` and `population()` to obtain the final
+    /// Build via [`ReveaBuilder`](crate::algorithms::ReveaBuilder),
+    /// then call `run()` and `population()` to obtain the final
     /// Pareto approximation.
     Revea,
     RandomSelection,

--- a/moors/src/operators/survival/mod.rs
+++ b/moors/src/operators/survival/mod.rs
@@ -2,7 +2,6 @@ pub mod moo;
 pub mod soo;
 
 use crate::{
-    algorithms::AlgorithmContext,
     genetic::{D12, Population},
     random::RandomGenerator,
 };
@@ -22,7 +21,6 @@ pub trait SurvivalOperator {
         population: Population<Self::FDim, ConstrDim>,
         num_survive: usize,
         rng: &mut impl RandomGenerator,
-        algorithm_context: &AlgorithmContext,
     ) -> Population<Self::FDim, ConstrDim>
     where
         ConstrDim: D12;

--- a/moors/src/operators/survival/moo/agemoea.rs
+++ b/moors/src/operators/survival/moo/agemoea.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 
 use crate::{
-    algorithms::AlgorithmContext,
     genetic::{D12, Fronts},
     helpers::{
         extreme_points::get_ideal,
@@ -45,18 +44,11 @@ impl HyperPlaneNormalization for AgeMoeaHyperPlaneNormalization {
 #[derive(Debug, Clone)]
 pub struct AgeMoeaSurvival;
 
-impl AgeMoeaSurvival {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
 impl FrontsAndRankingBasedSurvival for AgeMoeaSurvival {
     fn set_front_survival_score<ConstrDim>(
         &self,
         fronts: &mut Fronts<ConstrDim>,
         _rng: &mut impl RandomGenerator,
-        _algorithm_context: &AlgorithmContext,
     ) where
         ConstrDim: D12,
     {
@@ -308,7 +300,6 @@ pub fn assign_survival_scores_higher_front(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::algorithms::helpers::AlgorithmContextBuilder;
     use crate::genetic::PopulationMOO;
     use crate::operators::survival::moo::helpers::HyperPlaneNormalization;
     use crate::random::NoopRandomGenerator;
@@ -466,13 +457,9 @@ mod tests {
         // Set the desired number of survivors (e.g., 4).
         let num_survive = 4;
 
-        let mut operator = AgeMoeaSurvival::new();
+        let mut operator = AgeMoeaSurvival;
         let mut rng = NoopRandomGenerator::new();
-        // create context (not used in the algorithm)
-        let _context = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
-        let survivors = operator.operate(population, num_survive, &mut rng, &_context);
+        let survivors = operator.operate(population, num_survive, &mut rng);
 
         assert_eq!(
             survivors.len(),

--- a/moors/src/operators/survival/moo/mod.rs
+++ b/moors/src/operators/survival/moo/mod.rs
@@ -1,5 +1,4 @@
 use crate::{
-    algorithms::AlgorithmContext,
     genetic::{D12, Fronts, FrontsExt, PopulationMOO},
     non_dominated_sorting::build_fronts,
     operators::survival::SurvivalOperator,
@@ -54,7 +53,6 @@ pub trait FrontsAndRankingBasedSurvival: SurvivalOperator<FDim = ndarray::Ix2> {
         &self,
         fronts: &mut Fronts<ConstrDim>,
         rng: &mut impl RandomGenerator,
-        algorithm_context: &AlgorithmContext,
     ) where
         ConstrDim: D12;
 
@@ -65,7 +63,6 @@ pub trait FrontsAndRankingBasedSurvival: SurvivalOperator<FDim = ndarray::Ix2> {
         population: PopulationMOO<ConstrDim>,
         num_survive: usize,
         rng: &mut impl RandomGenerator,
-        algorithm_context: &AlgorithmContext,
     ) -> PopulationMOO<ConstrDim>
     where
         ConstrDim: D12,
@@ -73,7 +70,7 @@ pub trait FrontsAndRankingBasedSurvival: SurvivalOperator<FDim = ndarray::Ix2> {
         // Build fronts
         let mut fronts = build_fronts(population, num_survive);
         // Set survival score
-        self.set_front_survival_score(&mut fronts, rng, algorithm_context);
+        self.set_front_survival_score(&mut fronts, rng);
         // Drain all fronts.
         let drained = fronts.drain(..);
         let mut survivors_parts: Vec<PopulationMOO<ConstrDim>> = Vec::new();
@@ -126,18 +123,11 @@ impl<T: FrontsAndRankingBasedSurvival> SurvivalOperator for T {
         population: PopulationMOO<ConstrDim>,
         num_survive: usize,
         rng: &mut impl RandomGenerator,
-        algorithm_context: &AlgorithmContext,
     ) -> PopulationMOO<ConstrDim>
     where
         ConstrDim: D12,
     {
         // Delegate to the FrontsAndRankingBasedSurvival default implementation
-        <T as FrontsAndRankingBasedSurvival>::operate(
-            self,
-            population,
-            num_survive,
-            rng,
-            algorithm_context,
-        )
+        <T as FrontsAndRankingBasedSurvival>::operate(self, population, num_survive, rng)
     }
 }

--- a/moors/src/operators/survival/moo/nsga2.rs
+++ b/moors/src/operators/survival/moo/nsga2.rs
@@ -3,7 +3,6 @@ use std::f64::INFINITY;
 use ndarray::{Array1, Array2};
 
 use crate::{
-    algorithms::AlgorithmContext,
     genetic::{D12, Fronts},
     operators::survival::moo::FrontsAndRankingBasedSurvival,
     random::RandomGenerator,
@@ -22,7 +21,6 @@ impl FrontsAndRankingBasedSurvival for Nsga2RankCrowdingSurvival {
         &self,
         fronts: &mut Fronts<ConstrDim>,
         _rng: &mut impl RandomGenerator,
-        _algorithm_context: &AlgorithmContext,
     ) where
         ConstrDim: D12,
     {
@@ -99,7 +97,6 @@ mod tests {
     use super::*;
     use ndarray::{Array2, Axis, array, concatenate};
 
-    use crate::algorithms::helpers::AlgorithmContextBuilder;
     use crate::genetic::PopulationMOO;
     use crate::random::NoopRandomGenerator;
 
@@ -195,11 +192,7 @@ mod tests {
 
         let selector = Nsga2RankCrowdingSurvival::new();
         let mut rng = NoopRandomGenerator::new();
-        // create context (not used in the algorithm)
-        let _context = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
-        selector.set_front_survival_score(&mut fronts, &mut rng, &_context);
+        selector.set_front_survival_score(&mut fronts, &mut rng);
 
         let expected: Array1<f64> = array![
             std::f64::INFINITY,
@@ -220,11 +213,7 @@ mod tests {
         let num_survive = 3;
         let mut selector = Nsga2RankCrowdingSurvival;
         let mut _rng = NoopRandomGenerator::new();
-        // create context (not used in the algorithm)
-        let _context = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
-        let new_population = selector.operate(population, num_survive, &mut _rng, &_context);
+        let new_population = selector.operate(population, num_survive, &mut _rng);
 
         // The resulting population should remain unchanged.
         assert_eq!(new_population.genes, genes);
@@ -267,11 +256,7 @@ mod tests {
 
         let mut selector = Nsga2RankCrowdingSurvival;
         let mut _rng = NoopRandomGenerator::new();
-        // create context (not used in the algorithm)
-        let _context = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
-        let new_population = selector.operate(population, num_survive, &mut _rng, &_context);
+        let new_population = selector.operate(population, num_survive, &mut _rng);
 
         // The final population must have 4 individuals.
         assert_eq!(new_population.len(), num_survive);

--- a/moors/src/operators/survival/moo/nsga3.rs
+++ b/moors/src/operators/survival/moo/nsga3.rs
@@ -4,7 +4,6 @@ use ndarray::{Array1, Array2, Axis, s};
 use ndarray_stats::QuantileExt;
 
 use crate::{
-    algorithms::AlgorithmContext,
     genetic::{D12, PopulationMOO},
     helpers::extreme_points::get_ideal,
     non_dominated_sorting::build_fronts,
@@ -94,7 +93,6 @@ impl SurvivalOperator for Nsga3ReferencePointsSurvival {
         population: PopulationMOO<ConstrDim>,
         num_survive: usize,
         rng: &mut impl RandomGenerator,
-        _algorithm_context: &AlgorithmContext,
     ) -> PopulationMOO<ConstrDim>
     where
         ConstrDim: D12,
@@ -337,7 +335,6 @@ fn niching(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::algorithms::helpers::AlgorithmContextBuilder;
     use crate::random::{RandomGenerator, TestDummyRng};
     use ndarray::array;
 
@@ -491,12 +488,8 @@ mod tests {
         let reference_points = Nsga3ReferencePoints::new(Array2::eye(2), false);
         let mut survival_operator = Nsga3ReferencePointsSurvival::new(reference_points);
         let mut rng = FakeRandomGenerator::new();
-        // create context (not used in the algorithm)
-        let _context = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
         // Set num_survive to 3 so that splitting must occur on the single front.
-        let survivors = survival_operator.operate(population, 3, &mut rng, &_context);
+        let survivors = survival_operator.operate(population, 3, &mut rng);
         assert_eq!(survivors.len(), 3, "Final survivors count should be 3");
 
         // Verify that each selected individual comes from the original front.
@@ -537,14 +530,10 @@ mod tests {
         let reference_points = Nsga3ReferencePoints::new(Array2::eye(2), false);
         let mut survival_operator = Nsga3ReferencePointsSurvival::new(reference_points);
         let mut rng = FakeRandomGenerator::new();
-        // create context (not used in the algorithm)
-        let _context = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
         // Total individuals if merged completely would be 7.
         // Set num_survive to 5 so that the first front (3 individuals) is completely taken
         // and 2 individuals are selected from the second front.
-        let survivors = survival_operator.operate(population, 5, &mut rng, &_context);
+        let survivors = survival_operator.operate(population, 5, &mut rng);
         assert_eq!(survivors.len(), 5, "Final survivors count should be 5");
 
         // Check that the survivors include all individuals from the first front.

--- a/moors/src/operators/survival/moo/rnsga2.rs
+++ b/moors/src/operators/survival/moo/rnsga2.rs
@@ -3,7 +3,6 @@ use std::cmp::Ordering;
 use ndarray::{Array1, Array2, ArrayView1, Axis};
 
 use crate::{
-    algorithms::AlgorithmContext,
     genetic::{D12, Fronts},
     helpers::extreme_points::{get_ideal, get_nadir},
     operators::survival::moo::{FrontsAndRankingBasedSurvival, SurvivalScoringComparison},
@@ -37,7 +36,6 @@ impl FrontsAndRankingBasedSurvival for Rnsga2ReferencePointsSurvival {
         &self,
         fronts: &mut Fronts<ConstrDim>,
         rng: &mut impl RandomGenerator,
-        _algorithm_context: &AlgorithmContext,
     ) where
         ConstrDim: D12,
     {

--- a/moors/src/operators/survival/moo/spea2.rs
+++ b/moors/src/operators/survival/moo/spea2.rs
@@ -3,7 +3,6 @@ use std::cmp::Ordering;
 use ndarray::{Array1, Array2, Axis};
 
 use crate::{
-    algorithms::AlgorithmContext,
     genetic::{D12, PopulationMOO},
     helpers::linalg::cross_euclidean_distances_as_array,
     non_dominated_sorting::fast_non_dominated_sorting,
@@ -28,7 +27,6 @@ impl SurvivalOperator for Spea2KnnSurvival {
         population: PopulationMOO<ConstrDim>,
         num_survive: usize,
         _rng: &mut impl RandomGenerator,
-        _algorithm_context: &AlgorithmContext,
     ) -> PopulationMOO<ConstrDim>
     where
         ConstrDim: D12,
@@ -193,7 +191,6 @@ mod tests {
     use super::*;
     use ndarray::array;
 
-    use crate::algorithms::helpers::AlgorithmContextBuilder;
     use crate::random::NoopRandomGenerator;
 
     #[test]
@@ -319,22 +316,19 @@ mod tests {
         //        F₂ = 2 + 0.4784689  ≈ 2.4784689
         let expected_raw = [0.4016064, 1.4784689, 2.4784689];
 
-        // 3) Run operate with capacity = 2
+        // Run operate with capacity = 2
         let mut rng = NoopRandomGenerator::new();
-        let ctx = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
-        let survivors = Spea2KnnSurvival::new().operate(pop, 2, &mut rng, &ctx);
+        let survivors = Spea2KnnSurvival::new().operate(pop, 2, &mut rng);
 
-        // 4) Extract survivors’ survival_score fields
+        // Extract survivors’ survival_score fields
         let scores: Vec<f64> = survivors
             .survival_score
             .as_ref()
             .expect("survival_score must be set")
             .to_vec();
 
-        // 5) Underflow picks indices 0 and 1, so we expect
-        //    [expected_raw[0], expected_raw[1]]
+        // Underflow picks indices 0 and 1, so we expect
+        // [expected_raw[0], expected_raw[1]]
         assert_eq!(scores.len(), 2);
         assert!((scores[0] - expected_raw[0]).abs() < 1e-6,);
         assert!((scores[1] - expected_raw[1]).abs() < 1e-6);
@@ -349,10 +343,7 @@ mod tests {
 
         // Capacity = 2 → overflow branch
         let mut rng = NoopRandomGenerator::new();
-        let ctx = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
-        let survivors = Spea2KnnSurvival::new().operate(pop, 2, &mut rng, &ctx);
+        let survivors = Spea2KnnSurvival::new().operate(pop, 2, &mut rng);
 
         // Expect exactly two survivors
         assert_eq!(survivors.len(), 2);
@@ -390,10 +381,7 @@ mod tests {
 
         // Capacity exactly equals population size (4) → no truncation
         let mut rng = NoopRandomGenerator::new();
-        let ctx = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
-        let survivors = Spea2KnnSurvival::new().operate(pop, 4, &mut rng, &ctx);
+        let survivors = Spea2KnnSurvival::new().operate(pop, 4, &mut rng);
 
         // all individuals must survive
         assert_eq!(survivors.len(), 4);

--- a/moors/src/operators/survival/soo/fitness.rs
+++ b/moors/src/operators/survival/soo/fitness.rs
@@ -3,7 +3,6 @@ use std::cmp::Ordering;
 use ndarray::Array1;
 
 use crate::{
-    algorithms::AlgorithmContext,
     genetic::{D12, PopulationSOO},
     operators::survival::SurvivalOperator,
     random::RandomGenerator,
@@ -32,7 +31,6 @@ impl SurvivalOperator for FitnessSurvival {
         population: PopulationSOO<ConstrDim>,
         num_survive: usize,
         _rng: &mut impl RandomGenerator,
-        _algorithm_context: &AlgorithmContext,
     ) -> PopulationSOO<ConstrDim>
     where
         ConstrDim: D12,
@@ -78,8 +76,6 @@ mod tests {
     use crate::random::TestDummyRng;
     use ndarray::{Array2, array};
 
-    use crate::algorithms::helpers::AlgorithmContextBuilder;
-
     // A fake random generator; FitnessSurvival does not actually use RNG here,
     // but we need to satisfy the trait bound.
     struct FakeRandomGenerator {
@@ -112,13 +108,8 @@ mod tests {
         let fitness = array![0.8, 0.2, 0.5, 0.1];
         let pop = PopulationSOO::new_unconstrained(genes, fitness);
         let mut rng = FakeRandomGenerator::new();
-        // create context (not used in the algorithm)
-        let _context = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
-
         let mut selector = FitnessSurvival;
-        let survived = selector.operate(pop, 2, &mut rng, &_context);
+        let survived = selector.operate(pop, 2, &mut rng);
 
         // survive_count = 2
         assert_eq!(survived.fitness.len(), 2);
@@ -143,13 +134,8 @@ mod tests {
         let constraints = array![0.0, 0.0, 10.0, 100.0];
         let pop = PopulationSOO::new(genes, fitness, constraints);
         let mut rng = FakeRandomGenerator::new();
-        // create context (not used in the algorithm)
-        let _context = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
-
         let mut selector = FitnessSurvival;
-        let survived = selector.operate(pop, 2, &mut rng, &_context);
+        let survived = selector.operate(pop, 2, &mut rng);
         // survive_count = 2
         assert_eq!(survived.fitness.len(), 2);
         // Survived fitnesses should be [0.2, 0.8]
@@ -169,13 +155,8 @@ mod tests {
         let fitness = array![0.3, 0.1, 0.2];
         let pop = PopulationSOO::new_unconstrained(genes, fitness);
         let mut rng = FakeRandomGenerator::new();
-        // create context (not used in the algorithm)
-        let _context = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
-
         let mut selector = FitnessSurvival;
-        let survived = selector.operate(pop, 5, &mut rng, &_context);
+        let survived = selector.operate(pop, 5, &mut rng);
 
         assert_eq!(survived.fitness.len(), 3);
         let expected_fitness = array![0.1, 0.2, 0.3];
@@ -192,13 +173,8 @@ mod tests {
         let fitness = array![0.42];
         let pop = PopulationSOO::new_unconstrained(genes, fitness);
         let mut rng = FakeRandomGenerator::new();
-        // create context (not used in the algorithm)
-        let _context = AlgorithmContextBuilder::default()
-            .build()
-            .expect("Failed to build context");
-
         let mut selector = FitnessSurvival;
-        let survived = selector.operate(pop, 1, &mut rng, &_context);
+        let survived = selector.operate(pop, 1, &mut rng);
 
         assert_eq!(survived.fitness.len(), 1);
         assert_eq!(survived.fitness[0], 0.42);

--- a/moors/tests/test_algorithms_dtlz2.rs
+++ b/moors/tests/test_algorithms_dtlz2.rs
@@ -102,7 +102,8 @@ fn test_revea_dtlz2_three_objectives() {
     let rp = DanAndDenisReferencePoints::new(100, 3).generate();
     let alpha = 2.5;
     let frequency = 0.2;
-    let survivor = ReveaReferencePointsSurvival::new(rp, alpha, frequency);
+    let num_iterations = 200;
+    let survivor = ReveaReferencePointsSurvival::new(rp, alpha, frequency, num_iterations);
     impl_constraints_fn!(MyConstr, lower_bound = 0.0, upper_bound = 1.0);
 
     // instantiate via builder
@@ -117,7 +118,7 @@ fn test_revea_dtlz2_three_objectives() {
         .num_vars(2)
         .population_size(100)
         .num_offsprings(100)
-        .num_iterations(200)
+        .num_iterations(num_iterations)
         .mutation_rate(0.05)
         .crossover_rate(0.9)
         .keep_infeasible(false)

--- a/moors/tests/tests_algorithms_generic.rs
+++ b/moors/tests/tests_algorithms_generic.rs
@@ -176,7 +176,8 @@ fn test_revea() {
     let rp = DanAndDenisReferencePoints::new(100, 2).generate();
     let alpha = 2.5;
     let frequency = 0.2;
-    let survivor = ReveaReferencePointsSurvival::new(rp, alpha, frequency);
+    let num_iterations = 100;
+    let survivor = ReveaReferencePointsSurvival::new(rp, alpha, frequency, num_iterations);
     let mut algorithm = ReveaBuilder::default()
         .sampler(RandomSamplingFloat::new(0.0, 1.0))
         .crossover(SimulatedBinaryCrossover::new(15.0))
@@ -188,7 +189,7 @@ fn test_revea() {
         .num_vars(2)
         .population_size(100)
         .num_offsprings(100)
-        .num_iterations(100)
+        .num_iterations(num_iterations)
         .mutation_rate(0.1)
         .crossover_rate(0.95)
         .keep_infeasible(false)


### PR DESCRIPTION
This PR fixes #159 but instead of making context optional it removes completely from the operators due that was being used in a single operator (Revea)